### PR TITLE
Add PATCH method endpoint to bugsRouter

### DIFF
--- a/src/bug/fixtures.ts
+++ b/src/bug/fixtures.ts
@@ -10,7 +10,7 @@ export const insect1: BugStructure = {
     "This is a detailed description for Insect One, explaining its features and behavior.",
   imageUrl: "https://example.com/insect1.jpg",
   isDangerous: false,
-  isFavorite: true,
+  isFavorite: false,
   order: "OrderOne",
   phylum: "Arthropoda",
 };

--- a/src/bug/router/__tests__/toggleIsFavoriteEndpoint.test.ts
+++ b/src/bug/router/__tests__/toggleIsFavoriteEndpoint.test.ts
@@ -1,30 +1,39 @@
 import request from "supertest";
-import { insect1, insect3 } from "../../fixtures.js";
 import app from "../../../server/app.js";
-import setupTestDatabase from "../../../test-utils/setupTestDatabase.js";
+import { insect1, insect3 } from "../../fixtures.js";
 import { BugResponse, ErrorResponse } from "../../../server/types.js";
+import { BugStructure } from "../../types.js";
+import setupTestDatabase from "../../../test-utils/setupTestDatabase.js";
 import statusCodes from "../../../globals/statusCodes.js";
 
 setupTestDatabase();
 
-describe("Given the GET /bugs/:id endpoint", () => {
-  describe("When it receives a request with Insect One's ID", () => {
-    test("Then it should respond with Insect One", async () => {
-      const response = await request(app).get(`/bugs/${insect1._id}`);
+describe("Given the PATCH /bugs/:id endpoint", () => {
+  describe("When it receives a request with Insect One's ID which is not a favorite bug", () => {
+    test("Then it should respond with Insect One which is a favorite bug", async () => {
+      const updatedInsectOne: BugStructure = {
+        ...insect1,
+        isFavorite: true,
+      };
+
+      const response = await request(app).patch(`/bugs/${insect1._id}`);
 
       const { bug } = response.body as BugResponse;
 
       expect(bug).toStrictEqual(
-        expect.objectContaining({ commonName: insect1.commonName }),
+        expect.objectContaining({
+          commonName: updatedInsectOne.commonName,
+          isFavorite: updatedInsectOne.isFavorite,
+        }),
       );
     });
   });
 
   describe("When it receives a request with Insect Three's ID which doesn't exist", () => {
-    test(`Then it should respond with error 404 'Bug with ID '${insect3._id}' doesn't exist`, async () => {
+    test(`Then it should respond with error 404 'Bug with ID ${insect3._id} doesn't exist'`, async () => {
       const expectedErrorMessage = `Bug with ID '${insect3._id}' doesn't exist`;
 
-      const response = await request(app).get(`/bugs/${insect3._id}`);
+      const response = await request(app).patch(`/bugs/${insect3._id}`);
 
       const { error } = response.body as ErrorResponse;
 
@@ -38,7 +47,7 @@ describe("Given the GET /bugs/:id endpoint", () => {
       const invalidId = "XXXX";
       const expectedErrorMessage = "Invalid object ID";
 
-      const response = await request(app).get(`/bugs/${invalidId}`);
+      const response = await request(app).patch(`/bugs/${invalidId}`);
 
       const { error } = response.body as ErrorResponse;
 

--- a/src/bug/router/bugsRouter.ts
+++ b/src/bug/router/bugsRouter.ts
@@ -11,5 +11,6 @@ bugsRouter.get("/", bugsController.getBugsData);
 bugsRouter.get("/:id", handleValidateId, bugsController.getBugById);
 bugsRouter.post("/", bugsController.addBug);
 bugsRouter.delete("/:id", handleValidateId, bugsController.deleteBugById);
+bugsRouter.patch("/:id", handleValidateId, bugsController.toggleIsFavorite);
 
 export default bugsRouter;


### PR DESCRIPTION
Added PATCH method endpoint to bugsRouter which receives a request containing a bug ID, validates the ID, and modifies the corresponding bug's isFavorite property to the opposite of what it currently is.